### PR TITLE
homepage: replace broken irc.lc link with webchat.oftc.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ href="https://github.com/bpftrace/bpftrace/blob/master/docs/tutorial_one_liners.
 forum</a></p>
 <p><a href="https://github.com/bpftrace/bpftrace/issues">Bug
 tracker</a></p>
-<p><a href="http://irc.lc/oftc/bpftrace/web@@@">IRC</a></p>
+<p><a href="https://webchat.oftc.net/?channels=%23bpftrace">IRC</a></p>
 <p><a href="https://github.com/bpftrace/bpftrace/">Github</a></p>
 <h3 id="example">Example</h3>
 <p>Produce a histogram of time (in nanoseconds) spent in

--- a/src/index.md
+++ b/src/index.md
@@ -10,7 +10,7 @@ High-level tracing language for Linux systems
 
 [Bug tracker](https://github.com/bpftrace/bpftrace/issues)
 
-[IRC](http://irc.lc/oftc/bpftrace/web@@@)
+[IRC](https://webchat.oftc.net/?channels=%23bpftrace)
 
 [Github](https://github.com/bpftrace/bpftrace/)
 


### PR DESCRIPTION
The IRC link currently points to a domain auction website. Replace it with the OFTC webchat.

# Test plan

Opened `index.html` in Firefox, clicked it, and it worked.